### PR TITLE
Type params for Failable/Box static factory methods

### DIFF
--- a/src/main/groovy/com/johnnywey/flipside/Boxes.groovy
+++ b/src/main/groovy/com/johnnywey/flipside/Boxes.groovy
@@ -11,11 +11,11 @@ import com.johnnywey.flipside.box.Some
  * {@code None()}
  */
 class Boxes {
-    public static Box Some(value) {
+    public static <T> Box<T> Some(T value) {
         new Some(value)
     }
 
-    public static Box None() {
+    public static <T> Box<T> None() {
         new None()
     }
 }

--- a/src/main/groovy/com/johnnywey/flipside/Failables.groovy
+++ b/src/main/groovy/com/johnnywey/flipside/Failables.groovy
@@ -12,11 +12,11 @@ import com.johnnywey.flipside.failable.Success
  * {@code Failed(Fail.INVALID , "Invalid")}
  */
 class Failables {
-    public static Failable Failed(Fail reason, String detail) {
+    public static <T> Failable<T> Failed(Fail reason, String detail) {
         new Failed(reason, detail)
     }
 
-    public static Failable Succeeded(value) {
+    public static <T> Failable<T> Succeeded(T value) {
         new Success(value)
     }
 }

--- a/src/test/groovy/com/johnnywey/flipside/BoxSpec.groovy
+++ b/src/test/groovy/com/johnnywey/flipside/BoxSpec.groovy
@@ -1,5 +1,6 @@
 package com.johnnywey.flipside
 
+import com.johnnywey.flipside.box.Box
 import spock.lang.Specification
 
 class BoxSpec extends Specification {
@@ -28,5 +29,23 @@ class BoxSpec extends Specification {
         thrown(UnsupportedOperationException)
         empty.isEmpty()
         empty.getOrElse("ELSE") == "ELSE"
+    }
+
+    def "test parameterized static factory methods"() {
+        expect:
+        aJavaStyleMethod(content).isEmpty() == empty
+
+        where:
+        content | empty
+        ""      | true
+        "test"  | false
+    }
+
+    private static Box<String> aJavaStyleMethod(final String contents) {
+        if (contents) {
+            return Boxes.Some(contents)
+        }
+
+        return Boxes.None()
     }
 }

--- a/src/test/groovy/com/johnnywey/flipside/FailableSpec.groovy
+++ b/src/test/groovy/com/johnnywey/flipside/FailableSpec.groovy
@@ -1,6 +1,7 @@
 package com.johnnywey.flipside
 
 import com.johnnywey.flipside.failable.Fail
+import com.johnnywey.flipside.failable.Failable
 import com.johnnywey.flipside.failable.FailableException
 import spock.lang.Specification
 
@@ -57,5 +58,23 @@ class FailableSpec extends Specification {
         Fail.fromHttpResponseCode(504) == Fail.CONNECT_TIMEOUT
         Fail.fromHttpResponseCode(10020) == null
         Fail.fromHttpResponseCode(null) == null
+    }
+
+    def "test parameterized static factory methods"() {
+        expect:
+        aJavaStyleMethod(fail).reason == reason
+
+        where:
+        fail  | reason
+        false | Fail.SUCCESS
+        true  | Fail.INVALID_PARAMETERS
+    }
+
+    private static Failable<String> aJavaStyleMethod(final boolean fail) {
+        if (fail) {
+            return Failables.Failed(Fail.INVALID_PARAMETERS, "This test failed")
+        }
+
+        return Failables.Succeeded("This test passed")
     }
 }


### PR DESCRIPTION
This adds some type parameters to the static factory methods for Failables and Boxes to avoid type warnings in java code.

The goal here is so you can have some java code like this, without a bunch of nasty warnings:
```java
import static com.johnnywey.flipside.Failables.*;
...
public Failable<String> doAThing(boolean doIt) {
	if (doIt) {
		return Succeeded("It worked!");
	}

	return Failed(Fail.BAD_REQUEST, "It didn't work :(");
}
```