### PR TITLE
Add functional methods for Failables, Markers, and Boxes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ apply plugin: 'idea'
 
 ext.artifactId = 'flipside'
 group = 'com.johnnywey'
-version = '0.1.23-SNAPSHOT'
+version = '0.1.24-SNAPSHOT'
 
 jar {
     baseName = artifactId

--- a/src/main/java/com/johnnywey/flipside/box/Box.java
+++ b/src/main/java/com/johnnywey/flipside/box/Box.java
@@ -18,7 +18,7 @@ public interface Box<T> {
      *
      * @param consumer the consumer to invoke if this Box is full
      */
-    void ifPresent(BoxConsumer<T> consumer);
+    void ifPresent(BoxConsumer<? super T> consumer);
 
     /**
      * Defines the 'Groovy Truth' of this Box.

--- a/src/main/java/com/johnnywey/flipside/box/Box.java
+++ b/src/main/java/com/johnnywey/flipside/box/Box.java
@@ -13,6 +13,14 @@ public interface Box<T> {
     Boolean isEmpty();
 
     /**
+     * If the box is full, invoke the specified consumer with the value of {@link #get()}, otherwise do nothing.
+     * Works similarly to {@code Optional#ifPresent} in JDK 8+.
+     *
+     * @param consumer the consumer to invoke if this Box is full
+     */
+    void ifPresent(BoxConsumer<T> consumer);
+
+    /**
      * Defines the 'Groovy Truth' of this Box.
      *
      * @return true if this Box has contents, false otherwise

--- a/src/main/java/com/johnnywey/flipside/box/BoxConsumer.java
+++ b/src/main/java/com/johnnywey/flipside/box/BoxConsumer.java
@@ -1,0 +1,10 @@
+package com.johnnywey.flipside.box;
+
+/**
+ * Represents a function that should be called if a {@link Box} has {@link Some}.
+ * Use with {@link Box#ifPresent}.
+ */
+public abstract class BoxConsumer<T> {
+
+    abstract void onValuePresent(T t);
+}

--- a/src/main/java/com/johnnywey/flipside/box/BoxConsumer.java
+++ b/src/main/java/com/johnnywey/flipside/box/BoxConsumer.java
@@ -4,7 +4,7 @@ package com.johnnywey.flipside.box;
  * Represents a function that should be called if a {@link Box} has {@link Some}.
  * Use with {@link Box#ifPresent}.
  */
-public abstract class BoxConsumer<T> {
+public interface BoxConsumer<T> {
 
-    abstract void onValuePresent(T t);
+    void onValuePresent(T t);
 }

--- a/src/main/java/com/johnnywey/flipside/box/None.java
+++ b/src/main/java/com/johnnywey/flipside/box/None.java
@@ -26,6 +26,11 @@ public class None<T> implements Box<T>, Serializable {
     }
 
     @Override
+    public void ifPresent(final BoxConsumer<T> consumer) {
+        // Do nothing
+    }
+
+    @Override
     public boolean asBoolean() {
         return false;
     }

--- a/src/main/java/com/johnnywey/flipside/box/None.java
+++ b/src/main/java/com/johnnywey/flipside/box/None.java
@@ -26,7 +26,7 @@ public class None<T> implements Box<T>, Serializable {
     }
 
     @Override
-    public void ifPresent(final BoxConsumer<T> consumer) {
+    public void ifPresent(final BoxConsumer<? super T> consumer) {
         // Do nothing
     }
 

--- a/src/main/java/com/johnnywey/flipside/box/Some.java
+++ b/src/main/java/com/johnnywey/flipside/box/Some.java
@@ -32,6 +32,11 @@ public class Some<T> implements Box<T>, Serializable {
     }
 
     @Override
+    public void ifPresent(final BoxConsumer<T> consumer) {
+        consumer.onValuePresent(result);
+    }
+
+    @Override
     public boolean asBoolean() {
         return true;
     }

--- a/src/main/java/com/johnnywey/flipside/box/Some.java
+++ b/src/main/java/com/johnnywey/flipside/box/Some.java
@@ -32,7 +32,7 @@ public class Some<T> implements Box<T>, Serializable {
     }
 
     @Override
-    public void ifPresent(final BoxConsumer<T> consumer) {
+    public void ifPresent(final BoxConsumer<? super T> consumer) {
         consumer.onValuePresent(result);
     }
 

--- a/src/main/java/com/johnnywey/flipside/failable/Failable.java
+++ b/src/main/java/com/johnnywey/flipside/failable/Failable.java
@@ -15,6 +15,14 @@ public interface Failable<T> {
     DidItWork toDidItWork();
 
     /**
+     * If the operation is successful, invoke the specified consumer with the value of {@link #get()},
+     * otherwise do nothing.  Works similarly to {@code Optional#ifPresent} in JDK 8+.
+     *
+     * @param consumer the consumer to invoke if this Failable succeeded
+     */
+    void ifSuccessful(FailableConsumer<? super T> consumer);
+
+    /**
      * Defines the 'Groovy Truth' of this Failable.
      *
      * @return true if this Failable indicates success, false otherwise

--- a/src/main/java/com/johnnywey/flipside/failable/FailableConsumer.java
+++ b/src/main/java/com/johnnywey/flipside/failable/FailableConsumer.java
@@ -4,7 +4,7 @@ package com.johnnywey.flipside.failable;
  * Represents a function that should be called upon successful completion of a {@link Failable}.
  * Use with {@link Failable#ifSuccessful}.
  */
-public abstract class FailableConsumer<T> {
+public interface FailableConsumer<T> {
 
-    abstract void onSuccess(T t);
+    void onSuccess(T t);
 }

--- a/src/main/java/com/johnnywey/flipside/failable/FailableConsumer.java
+++ b/src/main/java/com/johnnywey/flipside/failable/FailableConsumer.java
@@ -1,0 +1,10 @@
+package com.johnnywey.flipside.failable;
+
+/**
+ * Represents a function that should be called upon successful completion of a {@link Failable}.
+ * Use with {@link Failable#ifSuccessful}.
+ */
+public abstract class FailableConsumer<T> {
+
+    abstract void onSuccess(T t);
+}

--- a/src/main/java/com/johnnywey/flipside/failable/Failed.java
+++ b/src/main/java/com/johnnywey/flipside/failable/Failed.java
@@ -50,6 +50,11 @@ public class Failed<T> implements Failable<T>, Serializable {
     }
 
     @Override
+    public void ifSuccessful(final FailableConsumer<? super T> consumer) {
+        // Do nothing
+    }
+
+    @Override
     public boolean asBoolean() {
         return false;
     }

--- a/src/main/java/com/johnnywey/flipside/failable/Success.java
+++ b/src/main/java/com/johnnywey/flipside/failable/Success.java
@@ -48,6 +48,11 @@ public class Success<T> implements Failable<T>, Serializable {
     }
 
     @Override
+    public void ifSuccessful(final FailableConsumer<? super T> consumer) {
+        consumer.onSuccess(result);
+    }
+
+    @Override
     public boolean asBoolean() {
         return true;
     }

--- a/src/main/java/com/johnnywey/flipside/marker/DidItWork.java
+++ b/src/main/java/com/johnnywey/flipside/marker/DidItWork.java
@@ -19,6 +19,13 @@ public interface DidItWork {
     Boolean isSuccess();
 
     /**
+     * If the operation worked, invoke the specified consumer, otherwise do nothing.
+     *
+     * @param consumer the consumer to invoke if this worked
+     */
+    void ifItWorked(MarkerConsumer consumer);
+
+    /**
      * Defines the 'Groovy Truth' of this Marker.
      *
      * @return true if this Marker indicates success, false otherwise

--- a/src/main/java/com/johnnywey/flipside/marker/DidNotWork.java
+++ b/src/main/java/com/johnnywey/flipside/marker/DidNotWork.java
@@ -35,6 +35,11 @@ public class DidNotWork implements DidItWork, Serializable {
     }
 
     @Override
+    public void ifItWorked(final MarkerConsumer consumer) {
+        // Do nothing
+    }
+
+    @Override
     public boolean asBoolean() {
         return false;
     }

--- a/src/main/java/com/johnnywey/flipside/marker/MarkerConsumer.java
+++ b/src/main/java/com/johnnywey/flipside/marker/MarkerConsumer.java
@@ -1,0 +1,10 @@
+package com.johnnywey.flipside.marker;
+
+/**
+ * Represents a function that should be called once a {@link DidItWork} has {@link Worked}.
+ * Use with {@link DidItWork#ifItWorked}.
+ */
+public abstract class MarkerConsumer {
+
+    abstract void onItWorked();
+}

--- a/src/main/java/com/johnnywey/flipside/marker/MarkerConsumer.java
+++ b/src/main/java/com/johnnywey/flipside/marker/MarkerConsumer.java
@@ -4,7 +4,7 @@ package com.johnnywey.flipside.marker;
  * Represents a function that should be called once a {@link DidItWork} has {@link Worked}.
  * Use with {@link DidItWork#ifItWorked}.
  */
-public abstract class MarkerConsumer {
+public interface MarkerConsumer {
 
-    abstract void onItWorked();
+    void onItWorked();
 }

--- a/src/main/java/com/johnnywey/flipside/marker/Worked.java
+++ b/src/main/java/com/johnnywey/flipside/marker/Worked.java
@@ -26,6 +26,11 @@ public class Worked implements DidItWork, Serializable {
     }
 
     @Override
+    public void ifItWorked(final MarkerConsumer consumer) {
+        consumer.onItWorked();
+    }
+
+    @Override
     public boolean asBoolean() {
         return true;
     }

--- a/src/test/groovy/com/johnnywey/flipside/BoxSpec.groovy
+++ b/src/test/groovy/com/johnnywey/flipside/BoxSpec.groovy
@@ -47,6 +47,26 @@ class BoxSpec extends Specification {
         !Boxes.None()
     }
 
+    def "test if present callback"() {
+        setup:
+        def callbackWasCalled = false
+
+        when: "the box is empty"
+        Boxes.None().ifPresent { callbackWasCalled = true }
+
+        then: "the callback should not be called"
+        !callbackWasCalled
+
+        when: "the box is full"
+        Boxes.Some("Presents!").ifPresent { contents ->
+            assert contents == "Presents!"
+            callbackWasCalled = true
+        }
+
+        then: "the callback should have been called"
+        callbackWasCalled
+    }
+
     private static Box<String> aJavaStyleMethod(final String contents) {
         if (contents) {
             return Boxes.Some(contents)

--- a/src/test/groovy/com/johnnywey/flipside/DidItWorkSpec.groovy
+++ b/src/test/groovy/com/johnnywey/flipside/DidItWorkSpec.groovy
@@ -28,4 +28,21 @@ class DidItWorkSpec extends Specification {
         Markers.Worked()
         !Markers.DidNotWork(Fail.BAD_REQUEST, "failure")
     }
+
+    def "test it worked callback"() {
+        setup:
+        def callbackWasCalled = false
+
+        when: "it didn't work :("
+        Markers.DidNotWork(Fail.INTERNAL_ERROR, "This failed").ifItWorked { callbackWasCalled = true }
+
+        then: "the callback should not be called"
+        !callbackWasCalled
+
+        when: "it worked!"
+        Markers.Worked().ifItWorked() { callbackWasCalled = true }
+
+        then: "the callback should have been called"
+        callbackWasCalled
+    }
 }

--- a/src/test/groovy/com/johnnywey/flipside/FailableSpec.groovy
+++ b/src/test/groovy/com/johnnywey/flipside/FailableSpec.groovy
@@ -76,6 +76,26 @@ class FailableSpec extends Specification {
         !Failables.Failed(Fail.BAD_REQUEST, "failure")
     }
 
+    def "test on success callback"() {
+        setup:
+        def callbackWasCalled = false
+
+        when: "the failable didn't succeed"
+        Failables.Failed(Fail.INTERNAL_ERROR, "This failed").ifSuccessful { callbackWasCalled = true }
+
+        then: "the callback should not be called"
+        !callbackWasCalled
+
+        when: "the failable succeeded"
+        Failables.Succeeded("This succeeded").ifSuccessful { result ->
+            assert result == "This succeeded"
+            callbackWasCalled = true
+        }
+
+        then: "the callback should have been called"
+        callbackWasCalled
+    }
+
     private static Failable<String> aJavaStyleMethod(final boolean fail) {
         if (fail) {
             return Failables.Failed(Fail.INVALID_PARAMETERS, "This test failed")


### PR DESCRIPTION
This aims to add methods to `Failable`s, `Marker`s, and `Box`es that work similar to the `Optional#ifPresent` method in JDK 8+.  They are:
* `Failable#ifSuccessful`
* `DidItWork#ifItWorked`
* `Box#ifPresent`

Because this library is targeted at Java 1.6+, we can't use any of Java 8's built-in functional interfaces like `Consumer`, so I created new functional interfaces for each of these.  That way, someone using Java 6 or 7 could still potentially use these, just using old-school explicit anonymous classes 😝.