### PR TITLE
Added CONFLICT(409) to Fail enum.

### DIFF
--- a/src/main/java/com/johnnywey/flipside/failable/Fail.java
+++ b/src/main/java/com/johnnywey/flipside/failable/Fail.java
@@ -18,6 +18,7 @@ public enum Fail {
     INTERNAL_ERROR(500),
     ACCESS_DENIED(403),
     INVALID_METHOD(405),
+    CONFLICT(409),
     ACCEPTED(202),
     SUCCESS(200); // place holder
 


### PR DESCRIPTION
Added CONFLICT(409) to Fail enum for johnnywey/flipside related to the following ticket:
https://trello.com/c/iiC7q9AE 